### PR TITLE
feat: add support for referencing recent commit titles in generation

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -17,3 +17,30 @@ pub fn get_staged_diff() -> Result<String> {
 
     Ok(diff)
 }
+
+/// Get the titles of the most recent commits
+pub fn get_recent_commit_titles(count: usize) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args([
+            "log",
+            &format!("-{}", count),
+            "--pretty=format:%s", // Only show commit subject
+            "--no-merges",        // Exclude merge commits
+            "--abbrev-commit",    // Abbreviate commit hashes
+        ])
+        .output()
+        .context("Failed to execute git log command")?;
+
+    if !output.status.success() {
+        let error_message = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to get recent commit titles: {}", error_message);
+    }
+
+    let titles = String::from_utf8(output.stdout)
+        .context("Parse git log output failed")?
+        .lines()
+        .map(String::from)
+        .collect();
+
+    Ok(titles)
+}


### PR DESCRIPTION
This commit introduces a new feature that allows the commit message generator to reference recent commit titles from the repository's history. The `generate_commit_message` function now accepts an optional `history_title` parameter, which can be populated with recent commit titles fetched using the new `get_recent_commit_titles` function in the `git` module. Additionally, a new CLI argument `--history` is added to control the number of recent commit titles to include as reference. This enhancement aims to provide more context-aware commit message suggestions.