### PR TITLE
ci: restructure GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build git-commit-generator"
+name: "Build and check"
 on:
   push:
     branches:
@@ -7,8 +7,8 @@ on:
     branches:
       - main
 jobs:
-  build:
-    name: Build on ${{ matrix.os }}
+  check:
+    name: Check on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -18,6 +18,15 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Flake check
         run: nix flake check --all-systems
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
       - name: Build Git Commit Generator
         run: nix build '.#git-commit-generator'
       - name: Upload Git Commit Generator


### PR DESCRIPTION
* Split build job into separate check and build jobs
* Move flake check to dedicated check job