### PR TITLE
refactor(nix): restructure flake into modular components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes pipe-operators
       - name: Flake check
         run: nix flake check --all-systems
   build:
@@ -27,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes pipe-operators
       - name: Build Git Commit Generator
         run: nix build -L
       - name: Upload Git Commit Generator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,10 @@ jobs:
           fi
           echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Setup Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes pipe-operators
       - name: Setup project
         run: |
           nix build -L

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,8 +12,10 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes pipe-operators
       - name: Update flake lock
         run: |
           nix flake update

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
       ];
       perSystem =
         {
+          inputs',
           pkgs,
           system,
           ...
@@ -40,19 +41,9 @@
           };
         in
         {
-          packages = {
-            git-msg = pkgs.callPackage ./nix/pkgs/git-msg.nix { };
-            default = self.packages.${system}.git-msg;
-          };
-          devShells.default = pkgs.mkShell {
-            inputsFrom = [ self.packages.${system}.git-msg ];
-            buildInputs = with pkgs; [
-              rust-analyzer
-              rustfmt
-            ];
-            RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
-            PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
-          };
+          imports = [
+            ./nix
+          ];
           formatter = treefmtEval.config.build.wrapper;
           checks = {
             formatting = treefmtEval.config.build.check self;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,3 @@
+{
+  imports = builtins.readDir ./modules |> builtins.attrNames |> map (name: ./modules/${name});
+}

--- a/nix/modules/devShells/default.nix
+++ b/nix/modules/devShells/default.nix
@@ -1,0 +1,12 @@
+{ pkgs, config, ... }:
+{
+  devShells.default = pkgs.mkShell {
+    inputsFrom = [ config.git-msg-bin ];
+    buildInputs = with pkgs; [
+      rust-analyzer
+      rustfmt
+    ];
+    RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+    PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+  };
+}

--- a/nix/modules/package/default.nix
+++ b/nix/modules/package/default.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  config,
+  pkgs,
+  system,
+  ...
+}:
+let
+  self = {
+    packages = (lib.mapAttrs (name: pkg: config.mkGitMsgWrapper name pkg) config.packagesSet) // {
+      git-msg = config.git-msg-bin;
+      default = self.packages.git-msg;
+    };
+  };
+in
+self

--- a/nix/modules/package/git-msg.nix
+++ b/nix/modules/package/git-msg.nix
@@ -13,9 +13,18 @@ pkgs.pkgsStatic.rustPlatform.buildRustPackage {
   version = "0.2.0";
 
   cargoLock = {
-    lockFile = ./../../Cargo.lock;
+    lockFile = ./../../../Cargo.lock;
   };
-  src = ./../..;
+  src =
+    with lib.fileset;
+    toSource {
+      root = ./../../..;
+      fileset = unions [
+        ./../../../src
+        ./../../../Cargo.lock
+        ./../../../Cargo.toml
+      ];
+    };
 
   PKG_CONFIG_PATH = "${pkgs.pkgsStatic.openssl.dev}/lib/pkgconfig";
 

--- a/nix/modules/treefmt/default.nix
+++ b/nix/modules/treefmt/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+{
+  treefmt = {
+    projectRootFile = "flake.nix";
+    programs = {
+      nixfmt.enable = true;
+      nixfmt.package = pkgs.nixfmt-rfc-style;
+    };
+    flakeCheck = true;
+  };
+}

--- a/nix/modules/wrapper/default.nix
+++ b/nix/modules/wrapper/default.nix
@@ -1,0 +1,138 @@
+{
+  pkgs,
+  lib,
+  config,
+  inputs',
+  ...
+}:
+let
+  message = lib.types.submodule {
+    options = {
+      style = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = "conventional";
+        description = "The Git commit message format style";
+        example = "conventional";
+      };
+      historyLength = lib.mkOption {
+        type = lib.types.nullOr lib.types.number;
+        default = null;
+        description = "The length of the git history to be used for generating commit messages";
+        example = 5;
+      };
+      modelType = lib.mkOption {
+        type = lib.types.str;
+        default = "deepseek-chat";
+        description = "The LLM model type to be used for generating commit messages";
+        example = "deepseek-chat"; # Or "deepseek-reasoner"
+      };
+    };
+  };
+
+  pkgsType = lib.types.submodule {
+    options = {
+      format = lib.mkOption {
+        type = message;
+        default = { };
+        description = "The format style of this pacakge";
+      };
+
+      description = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Description of this packages";
+      };
+    };
+  };
+in
+{
+  options = {
+    git-msg-bin = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./../package/git-msg.nix { };
+      description = "The Git commit message generator";
+    };
+
+    packagesSet = lib.mkOption {
+      type = lib.types.attrsOf pkgsType;
+      default = { };
+      description = "The available packages for this module";
+    };
+
+    defaultPackage = lib.mkOption {
+      type = lib.types.package;
+      description = "The default package to be used for this module";
+    };
+
+    mkGitMsgWrapper = lib.mkOption {
+      type = lib.types.functionTo (lib.types.functionTo lib.types.package);
+      description = "function to wrap different Git commit message generator in shell scripts";
+    };
+  };
+
+  config = {
+    packagesSet = {
+      conventional = {
+        format = {
+          style = "conventional";
+          modelType = "deepseek-chat";
+          historyLength = 5;
+        };
+        description = "Git commit message generator with conventional style";
+      };
+
+      bracketed = {
+        format = {
+          style = "bracketed";
+          modelType = "deepseek-chat";
+          historyLength = 5;
+        };
+        description = "Git commit message generator with bracketed style";
+      };
+
+      plain = {
+        format = {
+          style = "plain";
+          modelType = "deepseek-chat";
+          historyLength = 5;
+        };
+        description = "Git commit message generator with plain style";
+      };
+    };
+
+    mkGitMsgWrapper =
+      name: pkg:
+      let
+        formatConfig = pkg.format;
+        scriptsParams = [
+          "--model=${formatConfig.modelType}"
+          (lib.optionals (formatConfig.style != null) "--format=${formatConfig.style}")
+          (lib.optionals (
+            formatConfig.historyLength != null
+          ) "--git-history=${lib.toHexString formatConfig.historyLength}")
+        ];
+
+      in
+      pkgs.writeShellApplication {
+        name = "git-msg-${name}";
+        runtimeInputs = with pkgs; [
+          coreutils
+          git
+          config.git-msg-bin
+        ];
+        text = ''
+          echo "Welcome to Git Commit Generator Modules!"
+          echo "Format: ${formatConfig.style}"
+          echo "Git Commit Message Generator: ${config.git-msg-bin}"
+          echo "Params: ${lib.concatStringsSep " " scriptsParams}"
+          ${config.git-msg-bin}/bin/git-msg ${lib.concatStringsSep " " scriptsParams}
+        '';
+      };
+
+    defaultPackage =
+      let
+        formatName = "conventional";
+      in
+      config.mkGitMsgWrapper formatName config.packagesSet.${formatName};
+  };
+}


### PR DESCRIPTION
* Move package definitions and devShell into separate modules
* Add new wrapper module for git-msg configuration
* Reorganize treefmt configuration into its own module
* Update source filtering in git-msg package definition
* Implement new default.nix to auto-import all modules