### PR TITLE
Revert "chore: update flake lock 2025-05-12"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746576598,
-        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
+        "lastModified": 1746397377,
+        "narHash": "sha256-5oLdRa3vWSRbuqPIFFmQBGGUqaYZBxX+GGtN9f/n4lU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "rev": "ed30f8aba41605e3ab46421e3dcb4510ec560ff8",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746989248,
-        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
+        "lastModified": 1746216483,
+        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
+        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Reverts Emin017/git-commit-generator#52

Reason for revert:

The current Nix configuration for `arm64-apple-darwin` (macOS ARM) is encountering a linking error during the build of `rustc-1.86.0`'s bootstrap component. The linker fails to find `libiconv`:

```
  ld: library not found for -liconv
  clang: error: linker command failed with exit code 1
```

This issue appears to be an upstream problem within the `nixpkgs` derivation for `rustc` or its dependencies on this platform for the current `nixpkgs` revision.

Reverting to a previously working configuration to unblock CI/builds pending a fix from upstream `nixpkgs`.

Related error log:
<details>
<summary>Click to expand</summary>

```shell
error: builder for '/nix/store/nyxzvblaff1yd51qzmazfka5w0amf02i-arm64-apple-darwin-rustc-1.86.0.drv' failed with exit code 1;
       last 25 log lines:
       >    Compiling clap_complete v4.5.37
       >    Compiling build_helper v0.1.0 (/private/tmp/nix-build-arm64-apple-darwin-rustc-1.86.0.drv-0/rustc-1.86.0-src/src/build_helper)
       > error: linking with `/nix/store/cnlg9wy3n9iv8pzy4bvb4579am8i1pc4-arm64-apple-darwin-clang-wrapper-19.1.7/bin/arm64-apple-darwin-clang` failed: exit status: 1
       >   |
       >   = note:  "/nix/store/cnlg9wy3n9iv8pzy4bvb4579am8i1pc4-arm64-apple-darwin-clang-wrapper-19.1.7/bin/arm64-apple-darwin-clang" "/private/tmp/nix-build-arm64-apple-darwin-rustc-1.86.0.drv-0/rustcMTKf2I/symbols.o" "<11 object files omitted>" "/private/tmp/nix-build-arm64-apple-darwin-rustc-1.86.0.drv-0/rustc-1.86.0-src/build/bootstrap/debug/deps/{liblibc-3e66c5281446f194.rlib}.rlib" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,liballoc-*,librustc_std_workspace_core-*,libcore-*,libcompiler_builtins-*}.rlib" "-liconv" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.3.0" "-L" "/nix/store/9dwjxrl1dx29mhrk4fdxr36qq303s90a-xz-5.8.1/lib" "-o" "/private/tmp/nix-build-arm64-apple-darwin-rustc-1.86.0.drv-0/rustc-1.86.0-src/build/bootstrap/debug/deps/rustc-30a0a3a5d54fc35a" "-Wl,-dead_strip" "-nodefaultlibs"
       >   = note: some arguments are omitted. use `--verbose` to show all linker arguments
       >   = note: ld: warning: directory not found for option '-L/nix/store/xgnnwd7r3bblix2sxiy8f0p487w02xip-clang-19.1.7-lib/arm64-apple-darwin/lib'
       >           ld: library not found for -liconv
       >           clang: error: linker command failed with exit code 1 (use -v to see invocation)
       >
       >
       > error: could not compile `bootstrap` (bin "rustc") due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
```
</details>